### PR TITLE
Add alternate i2c address define 

### DIFF
--- a/Adafruit_LPS35HW.h
+++ b/Adafruit_LPS35HW.h
@@ -23,6 +23,7 @@
 #include <Wire.h>
 
 #define LPS35HW_I2CADDR_DEFAULT 0x5D ///< LPS35HW default i2c address
+#define LPS35HW_I2CADDR_ALT     0x5C ///< LPS35HW alternate i2c address
 #define LPS35HW_INTERRUPT_CFG 0x0B   ///< Interrupt configuration register
 #define LPS35HW_THS_P_L 0x0C         ///< Threshold pressure low byte
 #define LPS35HW_THS_P_H 0x0D         ///< Threshold pressure high byte


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.** 
    - I have added a define directive for the alternate I2C address supported by the sensor. (See section 6.3 of the LPS35HW datasheet) 
    - https://www.st.com/resource/en/datasheet/lps35hw.pdf#page=24

- **Describe any known limitations with your change.**  
    - No known limitations

- **Please run any tests or examples that can exercise your modified code.** 
    - Not sure how to make tests for a define, or if they're even needed. If needed, I can create some example code.
